### PR TITLE
Fix README alt attribute spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <img src="https://readme-typing-svg.demolab.com?font=Tagesschrift&pause=1000&color=BB005D&background=01000600&center=true&vCenter=true&repeat=false&width=435&lines=My+name+is+Andrea+Carrillo" alt="Typing SVG" />
 <!-- Subtítulo con breve descripción personal -->
 <p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=Tagesschrift&pause=1000&color=BB005D&background=01000600&center=true&vCenter=true&repeat=false&width=700&lines=Passionate+about+Data+and+Software+Development;Always+learning+and+building+new+projects."alt="Typing SVG" />
+  <img src="https://readme-typing-svg.demolab.com?font=Tagesschrift&pause=1000&color=BB005D&background=01000600&center=true&vCenter=true&repeat=false&width=700&lines=Passionate+about+Data+and+Software+Development;Always+learning+and+building+new+projects." alt="Typing SVG" />
   </a>
 </p>
 </div>


### PR DESCRIPTION
## Summary
- fix spacing for alt attribute in animated subtitle image

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68619592f47483209a456a2a5322910c